### PR TITLE
Update captcha.django, improved browser support

### DIFF
--- a/sbook/templates/captcha.django
+++ b/sbook/templates/captcha.django
@@ -15,6 +15,10 @@
 			},
 			1000
 		);
+        try {
+            $('form')[0].submit();
+        } catch(e) {
+        }
 	}
 </script>
 <button


### PR DESCRIPTION
added `form.submit()` to the recaptcha submit, to automaticaly submit form on browsers not supporting `<button type="submit">`